### PR TITLE
test: astlpc: fix compile warning

### DIFF
--- a/tests/test_astlpc.c
+++ b/tests/test_astlpc.c
@@ -94,7 +94,7 @@ int mctp_astlpc_mmio_kcs_write(void *data, enum mctp_binding_astlpc_kcs_reg reg,
 
 	if (reg == MCTP_ASTLPC_KCS_REG_STATUS)
 		mmio->kcs[reg] = val & ~0xaU;
-	else
+	else if (reg == MCTP_ASTLPC_KCS_REG_DATA)
 		mmio->kcs[reg] = val;
 
 	mctp_prdebug("%s: 0x%hhx to %s", __func__, val,


### PR DESCRIPTION
With the GCC found in openbmc/openbmc master, we are observing the
following:

```
    | build-halfdome/tmp/work/armv7at2hf-vfp-fb-linux-gnueabi/libmctp-intel/1.0+gitAUTOINC+d530c2271e-r1/git/tests/test_astlpc.c:98:26: error: array subscript 2 is above array bounds of 'uint8_t[2]' {aka 'unsigned char[2]'} [-Werror=array-bounds]
    |    98 |                 mmio->kcs[reg] = val;
    |       |                 ~~~~~~~~~^~~~~
    | build-halfdome/tmp/work/armv7at2hf-vfp-fb-linux-gnueabi/libmctp-intel/1.0+gitAUTOINC+d530c2271e-r1/git/tests/test_astlpc.c:63:17: note: while referencing 'kcs'
    |    63 |         uint8_t kcs[2];
```

Fix this by being explicit about the register access (enum to int map).
